### PR TITLE
Updated serialport version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "main": "./lib/obd.js",
   "dependencies": {
-    "serialport": "1.1.0"
+    "serialport": "1.1.x"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
There was an issue with version 1.1.0 on windows using proprietary libs which seems to be fixed in 1.1.1.
More info @ https://github.com/voodootikigod/node-serialport/issues/146

Check the building log @ http://webinoswintest.epu.ntua.gr/Home/BuildLog/76
