### PR TITLE
Queue consumer is now waiting for reply from OBD adapter

### DIFF
--- a/lib/obd.js
+++ b/lib/obd.js
@@ -13,6 +13,7 @@
  *
  * (C) Copyright 2013, TNO
  * Author: Eric Smekens
+ * Author: Frank Wammes
  */
 'use strict';
 //Used for event emitting.
@@ -37,6 +38,8 @@ var writeDelay = 50;
  */
 var queue = [];
 
+var lastSentCommand = '';
+
 // Class OBDReader
 var OBDReader;
 
@@ -52,7 +55,7 @@ OBDReader = function (portName, options) {
     EventEmitter.call(this);
     this.connected = false;
     this.receivedData = "";
-
+    this.awaitingReply = false;
     this.SERIAL_PORT = portName;
     this.OPTIONS = options;
 
@@ -142,7 +145,7 @@ function parseOBDCommand(hexString) {
 }
 /**
  * Connect/Open the serial port and add events to serial-port.
- * Also starts the intervalWriter that is used to write the queue.
+ * Also starts the .pushWriter that is used to write the queue.
  * @this {OBDReader}
  */
 OBDReader.prototype.connect = function () {
@@ -164,18 +167,18 @@ OBDReader.prototype.connect = function () {
         self.connected = true;
 
         //self.write('ATZ');
+        //Turns off echo.
+        self.write('ATE0');
         //Turns off extra line feed and carriage return
         self.write('ATL0');
         //This disables spaces in in output, which is faster!
         self.write('ATS0');
         //Turns off headers and checksum to be sent.
         self.write('ATH0');
-        //Turns off echo.
-        self.write('ATE0');
         //Turn adaptive timing to 2. This is an aggressive learn curve for adjusting the timeout. Will make huge difference on slow systems.
         self.write('ATAT2');
         //Set timeout to 10 * 4 = 40msec, allows +20 queries per second. This is the maximum wait-time. ATAT will decide if it should wait shorter or not.
-        //self.write('ATST0A');
+        self.write('ATST0A');
         //Set the protocol to automatic.
         self.write('ATSP0');
 
@@ -205,32 +208,49 @@ OBDReader.prototype.connect = function () {
                     if(messageString === '') {
                         continue;
                     }
+                    
+                    self.emit('debug', 'in    ' + messageString);
+
                     var reply;
                     reply = parseOBDCommand(messageString);
-                    //Event dataReceived.
+                    
                     self.emit('dataReceived', reply);
+                    if (self.awaitingReply == true) {
+                        self.awaitingReply = false;
+                        self.emit('processQueue');
+                    }
                     self.receivedData = '';
                 }
             }
         }
+        
+        
     });
 
     //this.serial = serial; //Save the connection in OBDReader object.
-
-    this.intervalWriter = setInterval(function (){
-        if(queue.length > 0 && self.connected)
-            try {
-                self.serial.write(queue.shift());
-            } catch (err) {
-                console.log('Error while writing: ' + err);
-                console.log('OBD-II Listeners deactivated, connection is probably lost.');
-                clearInterval(self.intervalWriter);
-                self.removeAllPollers();
+    this.on('processQueue', function () {
+        if(self.awaitingReply == true) {
+            self.emit('debug', 'processQueue: awaitingReply true')
+        } else {
+            if (queue.length > 0 && self.connected) {
+                try {
+                    self.awaitingReply = true;
+                    self.emit('debug', 'out   ' + queue[0]);
+                    lastSentCommand = queue[0];
+                    self.serial.write(queue.shift() + '\r');
+                } catch (err) {
+                    console.log('Error while writing: ' + err);
+                    console.log('OBD-II Listeners deactivated, connection is probably lost.');
+                    self.removeAllPollers();
+                }
             }
-    }, writeDelay); //Updated with Adaptive Timing on ELM327. 20 queries a second seems good enough.
-
+        }
+    });
+        
     return this;
 };
+
+
 
 /**
  * Disconnects/closes the port.
@@ -256,11 +276,17 @@ OBDReader.prototype.write = function (message, replies) {
     }
     if (this.connected) {
         if(queue.length < 256) {
+            this.emit('debug', 'queue ' + message + replies)
             if(replies !== 0) {
-                queue.push(message + replies + '\r');
+                queue.push(message + replies);
             } else {
-                queue.push(message + '\r');
+                queue.push(message);
             }
+            
+            if (this.awaitingReply == false) {
+                this.emit('processQueue');
+            }
+
         } else {
             console.log('Queue-overflow!');
         }

--- a/lib/obd.js
+++ b/lib/obd.js
@@ -13,7 +13,6 @@
  *
  * (C) Copyright 2013, TNO
  * Author: Eric Smekens
- * Author: Frank Wammes
  */
 'use strict';
 //Used for event emitting.


### PR DESCRIPTION
When adding multiple Pollers, I would get empty reply objects in the dataReceived event.

If the ELM327 is processing a request/command and you send input to it, it will abort its current process so you can regain control.

To fix this, I made the queue consumer wait for a reply before sending. and its not using setInterval anymore

