### PR TITLE
Due to the VIN is 17 ASCII chars, add a function to convert it to a char

### DIFF
--- a/lib/obdInfo.js
+++ b/lib/obdInfo.js
@@ -116,8 +116,18 @@ function notSupported() {
     return;
 }
 //VIN
-function convertVIN(byte) {
+function convertVIN_count(byte) {
     return byte;
+}
+function convertVIN(byte) {
+    byte = byte.split("");
+	var tmp=[], vin="";
+	for(i in byte){
+		tmp[i] = parseInt(byte[i]);
+		tmp[i] = parseInt(tmp[i], 16);
+		vin += String.fromCharCode(tmp[i]);
+	}
+	return vin;
 }
 
 var responsePIDS;
@@ -220,7 +230,7 @@ responsePIDS = [
 
     //VIN
     {mode: modeVin, pid: "00", bytes: 4, name: "vinsupp0", description: "Vehicle Identification Number", convertToUseful: bitDecoder},
-    {mode: modeVin, pid: "01", bytes: 1, name: "vin_mscout", description: "VIN message count", convertToUseful: convertVIN},
+    {mode: modeVin, pid: "01", bytes: 1, name: "vin_mscout", description: "VIN message count", convertToUseful: convertVIN_count},
     {mode: modeVin, pid: "02", bytes: 1, name: "vin", description: "Vehicle Identification Number", convertToUseful: convertVIN}
 ];
 

--- a/lib/obdInfo.js
+++ b/lib/obdInfo.js
@@ -220,7 +220,7 @@ responsePIDS = [
 
     //VIN
     {mode: modeVin, pid: "00", bytes: 4, name: "vinsupp0", description: "Vehicle Identification Number", convertToUseful: bitDecoder},
-    {mode: modeVin, pid: "01", bytes: 1, name: "vin", description: "Vehicle Identification Number", convertToUseful: convertVIN},
+    {mode: modeVin, pid: "01", bytes: 1, name: "vin_mscout", description: "VIN message count", convertToUseful: convertVIN},
     {mode: modeVin, pid: "02", bytes: 1, name: "vin", description: "Vehicle Identification Number", convertToUseful: convertVIN}
 ];
 


### PR DESCRIPTION
Due to the VIN is 17 ASCII chars, add a function to convert it to a char:
As the example given in datasheet, the input is "31 44 34 47 50 30 30 52 35 35 42 31 32 33 34 35 36"
And the output should be "1 D 4 G P 0 0 R 5 5 B 1 2 3 4 5 6"
So I add this function to do this job


Change the name of pin01 in Mode9 refer to the manual:
Mode 9
01	01	VIN message count
02	02	VIN (vehicle identification number)