### PR TITLE
add condition of unable to connect

### DIFF
--- a/lib/obd.js
+++ b/lib/obd.js
@@ -94,7 +94,7 @@ function parseOBDCommand(hexString) {
         valueArray; //New object
 
     reply = {};
-    if (hexString === "NO DATA" || hexString === "OK" || hexString === "?") { //No data or OK is the response.
+    if (hexString === "NO DATA" || hexString === "OK" || hexString === "?" || hexString === "UNABLE TO CONNECT") { //No data or OK is the response.
         reply.value = hexString;
         return reply;
     }
@@ -290,7 +290,7 @@ OBDReader.prototype.write = function (message, replies) {
             console.log('Queue-overflow!');
         }
     } else {
-        console.log('Bluetooth device is not connected.');
+        console.log('OBD Serial device is not connected.');
     }
 };
 /**


### PR DESCRIPTION
If there is only OBD2 but not connect to a car, use minicom or screen to send AT instruction will get "UNABLE TO CONNECT". 
Node-serial-obd have no respond to it, and would still process "UNABLE TO CONNECT" as data source. 
So I add this condition and it does work.