### PR TITLE
add condition that obd return searching

### DIFF
--- a/lib/obd.js
+++ b/lib/obd.js
@@ -94,6 +94,7 @@ function parseOBDCommand(hexString) {
         valueArray; //New object
 
     reply = {};
+	if (hexString === "SEARCHING...") return 1;
     if (hexString === "NO DATA" || hexString === "OK" || hexString === "?" || hexString === "UNABLE TO CONNECT") { //No data or OK is the response.
         reply.value = hexString;
         return reply;
@@ -212,8 +213,11 @@ OBDReader.prototype.connect = function () {
 
                     var reply;
                     reply = parseOBDCommand(messageString);
-                    
-                    self.emit('dataReceived', reply);
+
+                    if ( reply == 1 ) {
+					}else {
+                    	self.emit('dataReceived', reply);
+					}
                     if (self.awaitingReply == true) {
                         self.awaitingReply = false;
                         self.emit('processQueue');


### PR DESCRIPTION
Sometimes OBD will return "SEARCHING..." firstly, and then return the data source, so add this condition judgment to filter "SEARCHING..." message, otherwise the routine will parse and only return {}.