### PR TITLE
Remove undeclared variable this.intervalWriter

### DIFF
--- a/lib/obd.js
+++ b/lib/obd.js
@@ -251,7 +251,6 @@ OBDReader.prototype.connect = function () {
  * @this {OBDReader}
  */
 OBDReader.prototype.disconnect = function () {
-    clearInterval(this.intervalWriter);
     queue.length = 0; //Clears queue
     this.serial.close();
     this.connected = false;


### PR DESCRIPTION
`this.intervalWriter` is not mentioned anywhere else in the code.
It shouldn't be defined, if not added by external code.